### PR TITLE
Add support for `setup.py test`, tox, and Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 dist/
 MANIFEST
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: python
+
+python:
+  - 2.5
+  - 2.6
+  - 2.7
+
+install:
+    - pip install simplejson nose
+    - curl -O http://apache.mirrors.tds.net/lucene/solr/3.5.0/apache-solr-3.5.0.tgz
+    - tar xvzf apache-solr-3.5.0.tgz && SOLR_PATH=`pwd`/apache-solr-3.5.0/example
+
+before_script:
+    - cd $SOLR_PATH && java -jar start.jar &
+
+script: sleep 10 && python setup.py test
+
+branches:
+  only:
+    - testing
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[aliases]
+test = nosetests -v --with-doctest
+
+[nosetests]
+verbosity = 2

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 setup(
     name = "pysolr",
@@ -17,7 +20,8 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Indexing/Search'
     ],
     url = 'http://github.com/toastdriven/pysolr/',
-    extra_requires={
+    tests_require=['nose'],
+    extras_require={
         'tomcat': ['BeautifulSoup'],
     }
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py25, py26, py27, pypy
+
+[testenv]
+commands = {envpython} setup.py test
+deps = nose
+
+[testenv:py25]
+deps =
+    nose
+    simplejson


### PR DESCRIPTION
You can see Travis CI passing for my fork at http://travis-ci.org/msabramo/pysolr