### PR TITLE
fixed lxml errors when reading Tomcat error messages. 

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -426,25 +426,28 @@ class Solr(object):
         dom_tree = None
 
         if server_type == 'tomcat':
-            # Tomcat doesn't produce a valid XML response
-            soup = lxml.html.fromstring(response)
-            body_node = soup.find('body')
-            p_nodes = body_node.cssselect('p')
+            try:
+                # Tomcat doesn't produce a valid XML response
+                soup = lxml.html.fromstring(response)
+                body_node = soup.find('body')
+                p_nodes = body_node.cssselect('p')
+                for p_node in p_nodes:
+                    children = p_node.getchildren()
 
-            for p_node in p_nodes:
-                children = p_node.getchildren()
+                    if len(children) >= 2 and 'message' in children[0].text.lower():
+                        reason = children[1].text
 
-                if len(children) >= 2 and 'message' in children[0].text.lower():
-                    reason = children[1].text
+                    if len(children) >= 2 and hasattr(children[0], 'renderContents'):
+                        if 'description' in children[0].renderContents().lower():
+                            if reason is None:
+                                reason = children[1].renderContents()
+                            else:
+                                reason += ", " + children[1].renderContents()
+            except AttributeError:
+                # Except when it does
+                pass
 
-                if len(children) >= 2 and hasattr(children[0], 'renderContents'):
-                    if 'description' in children[0].renderContents().lower():
-                        if reason is None:
-                            reason = children[1].renderContents()
-                        else:
-                            reason += ", " + children[1].renderContents()
-
-            if reason is None:
+            if reason is None or p_nodes is None:
                 from lxml.html.clean import clean_html
                 full_html = clean_html(response)
         else:


### PR DESCRIPTION
When parsing error messages pysolr assumes that Tomcat will send a certain flavour of invalid response.

Sometime in Tomcat 6 (or maybe Solr4) the assertion that this code was based on became untrue, and so the error handling code in pysolr began creating it's own error. This may only be true when using lxml (it's required in my project so I haven't tested without).

This fix prevents pysolr from obscuring the tomcat error message with it's own, if it fails to find the tag it's looking for.

This is what I was getting before making this fix:

    File "/home/webapps/.virtualenvs/myapp/local/lib/python2.7/site-packages/pysolr.py", line 404, in _scrape_response
    p_nodes = body_node.cssselect('p')
    AttributeError: 'NoneType' object has no attribute 'cssselect'

