### PR TITLE
Update to specify lxml as required for Tomcat

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,9 +30,9 @@ Requirements
 
 * Python 2.6 - 3.3
 * Requests 2.0+
-* **Optional** - ``lxml``
+* **Optional** - ``lxml`` required for Tomcat error support
 * **Optional** - ``simplejson``
-* **Optional** - ``cssselect`` for Tomcat error support
+* **Optional** - ``cssselect`` required for Tomcat error support
 
 
 Installation


### PR DESCRIPTION
Lxml is not so much optional as required under certain circumstances. I added the tag 'required for Tomcat error support' to cssselect and lxml because lxml is imported with no try/except when the solr server is running on Tomcat.