### PR TITLE
Remove lxml requirement from error parsing

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -424,7 +424,6 @@ class Solr(object):
             server_type = 'jetty'
 
         if server_string and 'coyote' in server_string.lower():
-            import lxml.html
             server_type = 'tomcat'
 
         reason = None
@@ -433,26 +432,10 @@ class Solr(object):
 
         if server_type == 'tomcat':
             # Tomcat doesn't produce a valid XML response
-            soup = lxml.html.fromstring(response)
-            body_node = soup.find('body')
-            p_nodes = body_node.cssselect('p')
-
-            for p_node in p_nodes:
-                children = p_node.getchildren()
-
-                if len(children) >= 2 and 'message' in children[0].text.lower():
-                    reason = children[1].text
-
-                if len(children) >= 2 and hasattr(children[0], 'renderContents'):
-                    if 'description' in children[0].renderContents().lower():
-                        if reason is None:
-                            reason = children[1].renderContents()
-                        else:
-                            reason += ", " + children[1].renderContents()
-
-            if reason is None:
-                from lxml.html.clean import clean_html
-                full_html = clean_html(response)
+            if response.index('<h1>'):
+                reason = response[response.index('<h1>')+4:response.index('</h1>')]
+            else:
+                full_html = "%s" % response
         else:
             # Let's assume others do produce a valid XML response
             try:

--- a/pysolr.py
+++ b/pysolr.py
@@ -432,8 +432,8 @@ class Solr(object):
 
         if server_type == 'tomcat':
             # Tomcat doesn't produce a valid XML response
-            if response.index('<h1>'):
-                reason = response[response.index('<h1>')+4:response.index('</h1>')]
+            if response.find('<h1>') >= 0:
+                reason = response[response.find('<h1>')+4:response.find('</h1>')]
             else:
                 full_html = "%s" % response
         else:


### PR DESCRIPTION
LXML is overkill and not really required to make a decent error string. This is my take at a reasonable alternative to the htmlsoup parsing, removing a couple dependencies. While the htmlsoup parsing could be considered flexible it is still much more dependent on present form html structure than need be. I think the H1 will be long term more reliable error string than the more complicated pathing required of the current algorithm. Either way we are betting on the future output of an external project (solr + tomcat), and writing pretty fragile code. 