### PR TITLE
Optimize is no longer recommended

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,9 +68,6 @@ Basic usage looks like:
         },
     ])
 
-    # You can optimize the index when it gets fragmented, for better speed.
-    solr.optimize()
-
     # Later, searching is easy. In the simple case, just a plain Lucene-style
     # query is fine.
     results = solr.search('bananas')


### PR DESCRIPTION
Since Solr 3.6, Solr has used the TieredMergePolicy which makes,
in most scenarios, optimization a harmful rather than beneficial
step.

We should leave the feature in the client, but not publicize it, IMO.