### PR TITLE
Simple error extraction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,9 +30,7 @@ Requirements
 
 * Python 2.6 - 3.3
 * Requests 2.0+
-* **Optional** - ``lxml``
 * **Optional** - ``simplejson``
-* **Optional** - ``cssselect`` for Tomcat error support
 
 
 Installation

--- a/pysolr.py
+++ b/pysolr.py
@@ -426,9 +426,10 @@ class Solr(object):
         dom_tree = None
 
         if server_type == 'tomcat':
-            # Tomcat doesn't produce a valid XML response
-            if response.find('<h1>') >= 0:
-                reason = response[response.find('<h1>')+4:response.find('</h1>')]
+            # Tomcat doesn't produce a valid XML response or consistent HTML:
+            m = re.search(r'<(h1)[^>]*>\s*(.+?)\s*</\1>', response, re.IGNORECASE)
+            if m:
+                reason = m.group(2)
             else:
                 full_html = "%s" % response
         else:

--- a/pysolr.py
+++ b/pysolr.py
@@ -8,17 +8,12 @@ import logging
 import re
 import requests
 import time
-import types
 import ast
 
 try:
-    # Prefer lxml, if installed.
-    from lxml import etree as ET
+    from xml.etree import ElementTree as ET
 except ImportError:
-    try:
-        from xml.etree import cElementTree as ET
-    except ImportError:
-        raise ImportError("No suitable ElementTree implementation was found.")
+    raise ImportError("No suitable ElementTree implementation was found.")
 
 try:
     # Prefer simplejson, if installed.

--- a/pysolr.py
+++ b/pysolr.py
@@ -424,7 +424,6 @@ class Solr(object):
             server_type = 'jetty'
 
         if server_string and 'coyote' in server_string.lower():
-            import lxml.html
             server_type = 'tomcat'
 
         reason = None
@@ -433,26 +432,10 @@ class Solr(object):
 
         if server_type == 'tomcat':
             # Tomcat doesn't produce a valid XML response
-            soup = lxml.html.fromstring(response)
-            body_node = soup.find('body')
-            p_nodes = body_node.cssselect('p')
-
-            for p_node in p_nodes:
-                children = p_node.getchildren()
-
-                if len(children) >= 2 and 'message' in children[0].text.lower():
-                    reason = children[1].text
-
-                if len(children) >= 2 and hasattr(children[0], 'renderContents'):
-                    if 'description' in children[0].renderContents().lower():
-                        if reason is None:
-                            reason = children[1].renderContents()
-                        else:
-                            reason += ", " + children[1].renderContents()
-
-            if reason is None:
-                from lxml.html.clean import clean_html
-                full_html = clean_html(response)
+            if response.index('<h1>'):
+                reason = response[response.index('<h1>')+4:response.index('</h1>')]
+            else:
+                full_html = "%s" % response
         else:
             # Let's assume others do produce a valid XML response
             try:

--- a/pysolr.py
+++ b/pysolr.py
@@ -432,8 +432,8 @@ class Solr(object):
 
         if server_type == 'tomcat':
             # Tomcat doesn't produce a valid XML response
-            if response.index('<h1>'):
-                reason = response[response.index('<h1>')+4:response.index('</h1>')]
+            if response.find('<h1>') >= 0:
+                reason = response[response.find('<h1>')+4:response.find('</h1>')]
             else:
                 full_html = "%s" % response
         else:

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,5 @@ setup(
     license='BSD',
     install_requires=[
         'requests>=2.0'
-    ],
-    extras_require={
-        'tomcat': [
-            'lxml>=3.0',
-            'cssselect',
-        ],
-    }
+    ]
 )

--- a/tests/client.py
+++ b/tests/client.py
@@ -22,12 +22,6 @@ if IS_PY3:
 else:
     from StringIO import StringIO
 
-try:
-    import lxml
-    HAS_LXML = True
-except ImportError:
-    HAS_LXML = False
-
 
 class UtilsTestCase(unittest.TestCase):
     def test_unescape_html(self):
@@ -269,17 +263,11 @@ class SolrTestCase(unittest.TestCase):
         resp_2 = self.solr._scrape_response({'server': 'crapzilla'}, '<html><head><title>Wow. Seriously weird.</title></head><body><pre>Something is broke.</pre></body></html>')
         self.assertEqual(resp_2, ('Wow. Seriously weird.', u''))
 
-    @unittest.skipUnless(HAS_LXML, "Cannot test Tomcat error extraction without lxml")
     def test__scrape_response_tomcat(self):
-        """Tests for Tomcat error responses, which currently require lxml.html to parse"""
+        """Tests for Tomcat error responses"""
 
-        # Tomcat.
-        resp_1 = self.solr._scrape_response({'server': 'coyote'}, '<html><body><p><span>Error message</span><span>messed up.</span></p></body></html>')
-        self.assertEqual(resp_1, ('messed up.', ''))
-
-        # Broken Tomcat.
-        resp_2 = self.solr._scrape_response({'server': 'coyote'}, '<html><body><p>Really broken. Scraping Java-generated HTML sucks.</pre></body></html>')
-        self.assertEqual(resp_2, (None, u'<div><body><p>Really broken. Scraping Java-generated HTML sucks.</p></body></div>'))
+        resp_0 = self.solr._scrape_response({'server': 'coyote'}, '<html><body><h1>Something broke!</h1><pre>gigantic stack trace</pre></body></html>')
+        self.assertEqual(resp_0, ('Something broke!', ''))
 
     def test__from_python(self):
         self.assertEqual(self.solr._from_python(datetime.date(2013, 1, 18)), '2013-01-18T00:00:00Z')

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,6 @@ envlist = py26,py27,py33,py34,py26-tomcat,py27-tomcat,py33-tomcat,py34-tomcat
 deps =
     requests>=2.0
 
-[tomcat]
-deps =
-    lxml>=3
-    cssselect
-
 [testenv]
 commands = {toxinidir}/run-tests.py
 


### PR DESCRIPTION
This removes the lxml dependency from the error message parsing code – see e.g. #133, #72

If you're interesting in helping with this code, one thing we could use are some saved error messages from people using Solr in Tomcat so the test suite can run against something real.