### PR TITLE
Support Solr 4 error format parsing

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -439,6 +439,23 @@ class Solr(object):
         full_html = ''
         dom_tree = None
 
+        if response.startswith('<?xml'):
+            # Try a strict XML parse
+            try:
+                soup = ET.fromstring(response)
+            except ET.ParseError:
+                # XML parsing error, so we'll let the more liberal code handle it.
+                pass
+            else:
+                reason_node = soup.find("lst[@name='error']/str[@name='msg']")
+                tb_node = soup.find("lst[@name='error']/str[@name='trace']")
+                if reason_node is not None:
+                    full_html = reason = reason_node.text
+                if tb_node is not None:
+                    full_html = tb_node.text
+                    if reason is None:
+                        reason = full_html
+
         if server_type == 'tomcat':
             # Tomcat doesn't produce a valid XML response or consistent HTML:
             m = re.search(r'<(h1)[^>]*>\s*(.+?)\s*</\1>', response, re.IGNORECASE)

--- a/tests/client.py
+++ b/tests/client.py
@@ -268,11 +268,27 @@ class SolrTestCase(unittest.TestCase):
         resp_2 = self.solr._scrape_response({'server': 'crapzilla'}, '<html><head><title>Wow. Seriously weird.</title></head><body><pre>Something is broke.</pre></body></html>')
         self.assertEqual(resp_2, ('Wow. Seriously weird.', u''))
 
+        # Valid XML
+        resp_3 = self.solr._scrape_response({'server': 'coyote'}, '<?xml version="1.0"?>\n<response>\n<lst name="responseHeader"><int name="status">400</int><int name="QTime">0</int></lst><lst name="error"><str name="msg">Invalid Date String:\'2015-03-23 10:43:33\'</str><int name="code">400</int></lst>\n</response>\n')
+        self.assertEqual(resp_3, ("Invalid Date String:'2015-03-23 10:43:33'", "Invalid Date String:'2015-03-23 10:43:33'"))
+
+        # Valid XML with a traceback
+        resp_4 = self.solr._scrape_response({'server': 'coyote'}, """<?xml version="1.0"?>
+<response>
+<lst name="responseHeader"><int name="status">500</int><int name="QTime">138</int></lst><lst name="error"><str name="msg">Internal Server Error</str><str name="trace">org.apache.solr.common.SolrException: Internal Server Error at java.lang.Thread.run(Thread.java:745)</str><int name="code">500</int></lst>
+</response>""")
+        self.assertEqual(resp_4, (u"Internal Server Error", u"org.apache.solr.common.SolrException: Internal Server Error at java.lang.Thread.run(Thread.java:745)"))
+
     def test__scrape_response_tomcat(self):
         """Tests for Tomcat error responses"""
 
         resp_0 = self.solr._scrape_response({'server': 'coyote'}, '<html><body><h1>Something broke!</h1><pre>gigantic stack trace</pre></body></html>')
         self.assertEqual(resp_0, ('Something broke!', ''))
+
+        # Invalid XML
+        resp_3 = self.solr._scrape_response({'server': 'coyote'}, '<?xml version="1.0"?>\n<response>\n<lst name="responseHeader"><int name="status">400</int><int name="QTime">0</int></lst><lst name="error"><str name="msg">Invalid Date String:\'2015-03-23 10:43:33\'</str><int name="code">400</int></lst>')
+        self.assertEqual(resp_3, (None, "<div>4000Invalid Date String:'2015-03-23 10:43:33'400</div>"))
+
 
     def test__from_python(self):
         self.assertEqual(self.solr._from_python(datetime.date(2013, 1, 18)), '2013-01-18T00:00:00Z')


### PR DESCRIPTION
Currently pysolr doesn't support Solr 4 error messages while Solr 5 is already out. This patch adds support for parsing solr exceptions instead of masking them.

Replaces #60

@acdha @aarcro @akuchling