### PR TITLE
Refactor start-test-solr.sh to support Solr 4 and Solr 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,5 @@ env
 env3
 pysolr.egg-info/
 .tox
-solr*.tgz
-solr-*
+test-solr-server
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,10 @@
 build
 dist/
 MANIFEST
-solr4
 env
 env3
 pysolr.egg-info/
 .tox
 solr*.tgz
+solr-*
+*.log

--- a/run-tests.py
+++ b/run-tests.py
@@ -18,7 +18,8 @@ def start_solr():
 
     while True:
         try:
-            r = requests.get("http://localhost:8983/solr/core0/select/?q=startup")
+            # Solr 5 default schema requires the "df" field; it's deprecated in Solr 4 too
+            r = requests.get("http://localhost:8983/solr/collection1/select/?q=startup&df=id")
             status_code = r.status_code
         except requests.RequestException:
             status_code = 0

--- a/start-test-solr.sh
+++ b/start-test-solr.sh
@@ -4,6 +4,11 @@ set -e
 
 SOLR_VERSION=4.7.2
 
+if [ ! -d "test-solr-server" ]; then
+    mkdir "test-solr-server"
+fi
+cd "test-solr-server"
+
 export SOLR_ARCHIVE="solr-${SOLR_VERSION}.tgz"
 export SOLR_DIR="solr-${SOLR_VERSION}"
 

--- a/start-test-solr.sh
+++ b/start-test-solr.sh
@@ -4,9 +4,7 @@ set -e
 
 SOLR_VERSION=4.7.2
 
-if [ ! -d "test-solr-server" ]; then
-    mkdir "test-solr-server"
-fi
+mkdir -p "test-solr-server"
 cd "test-solr-server"
 
 export SOLR_ARCHIVE="solr-${SOLR_VERSION}.tgz"

--- a/tests/admin.py
+++ b/tests/admin.py
@@ -16,7 +16,7 @@ class SolrCoreAdminTestCase(unittest.TestCase):
 
     def test_status(self):
         self.assertTrue('name="defaultCoreName"' in self.solr_admin.status())
-        self.assertTrue('<int name="status">' in self.solr_admin.status(core='core0'))
+        self.assertTrue('<int name="status">' in self.solr_admin.status(core='collection1'))
 
     def test_create(self):
         self.assertTrue('<int name="status">0</int>' in self.solr_admin.create('wheatley'))

--- a/tests/client.py
+++ b/tests/client.py
@@ -111,9 +111,9 @@ class ResultsTestCase(unittest.TestCase):
 class SolrTestCase(unittest.TestCase):
     def setUp(self):
         super(SolrTestCase, self).setUp()
-        self.default_solr = Solr('http://localhost:8983/solr/core0')
+        self.default_solr = Solr('http://localhost:8983/solr/collection1')
         # Short timeouts.
-        self.solr = Solr('http://localhost:8983/solr/core0', timeout=2)
+        self.solr = Solr('http://localhost:8983/solr/collection1', timeout=2)
         self.docs = [
             {
                 'id': 'doc_1',
@@ -160,21 +160,21 @@ class SolrTestCase(unittest.TestCase):
         super(SolrTestCase, self).tearDown()
 
     def test_init(self):
-        self.assertEqual(self.default_solr.url, 'http://localhost:8983/solr/core0')
+        self.assertEqual(self.default_solr.url, 'http://localhost:8983/solr/collection1')
         self.assertTrue(isinstance(self.default_solr.decoder, json.JSONDecoder))
         self.assertEqual(self.default_solr.timeout, 60)
 
-        self.assertEqual(self.solr.url, 'http://localhost:8983/solr/core0')
+        self.assertEqual(self.solr.url, 'http://localhost:8983/solr/collection1')
         self.assertTrue(isinstance(self.solr.decoder, json.JSONDecoder))
         self.assertEqual(self.solr.timeout, 2)
 
     def test__create_full_url(self):
         # Nada.
-        self.assertEqual(self.solr._create_full_url(path=''), 'http://localhost:8983/solr/core0')
+        self.assertEqual(self.solr._create_full_url(path=''), 'http://localhost:8983/solr/collection1')
         # Basic path.
-        self.assertEqual(self.solr._create_full_url(path='pysolr_tests'), 'http://localhost:8983/solr/core0/pysolr_tests')
+        self.assertEqual(self.solr._create_full_url(path='pysolr_tests'), 'http://localhost:8983/solr/collection1/pysolr_tests')
         # Leading slash (& making sure we don't touch the trailing slash).
-        self.assertEqual(self.solr._create_full_url(path='/pysolr_tests/select/?whatever=/'), 'http://localhost:8983/solr/core0/pysolr_tests/select/?whatever=/')
+        self.assertEqual(self.solr._create_full_url(path='/pysolr_tests/select/?whatever=/'), 'http://localhost:8983/solr/collection1/pysolr_tests/select/?whatever=/')
 
     def test__send_request(self):
         # Test a valid request.
@@ -526,8 +526,8 @@ class SolrTestCase(unittest.TestCase):
         self.assertEqual(['Test Title ☃☃'], m['title'])
 
     def test_full_url(self):
-        self.solr.url = 'http://localhost:8983/solr/core0'
+        self.solr.url = 'http://localhost:8983/solr/collection1'
         full_url = self.solr._create_full_url(path='/update')
 
         # Make sure trailing and leading slashes do not collide:
-        self.assertEqual(full_url, 'http://localhost:8983/solr/core0/update')
+        self.assertEqual(full_url, 'http://localhost:8983/solr/collection1/update')


### PR DESCRIPTION
The test suite now uses a single-core example that's present in both Solr 4 and 5. The script detects the appropriate Solr version at runtime and prepares a Solr home directory accordingly. Some of the tests, which assumed the core is called "core0," have been modified to use a core called "collection1."

To be clear: the test suite runs with Solr 5, but it doesn't yet pass.

Also, the previous home directory used a two-core Solr configuration. I couldn't see anywhere that both cores were being used, and Solr 5 doesn't seem to have a corresponding "multicore" example, so this just uses the default single-core configuration now. If there's a real need for the multicore test configuration, or if you'd like me to make other changes, I'd be happy to revise my pull request!

I will be making the necessary changes for the test suite to pass with Solr 5.