### PR TITLE
logging: use better logging messages on HTTP status codes != 200

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -386,10 +386,12 @@ class Solr(object):
                       url, method, log_body[:10], end_time - start_time)
 
         if int(resp.status_code) != 200:
-            error_message = self._extract_error(resp)
-            self.log.error(error_message, extra={'data': {'headers': resp.headers,
-                                                          'response': resp.content}})
-            raise SolrError(error_message)
+            error_message = "Solr responded with an error (HTTP %s): %s"
+            solr_message = self._extract_error(resp)
+            self.log.error(error_message, resp.status_code, solr_message,
+                           extra={'data': {'headers': resp.headers,
+                                           'response': resp.content}})
+            raise SolrError(error_message % (resp.status_code, solr_message))
 
         return force_unicode(resp.content)
 


### PR DESCRIPTION
We already extract error message from Solr responses and that is great. Unfortunately it can contain the data that may change with every request (like document id).

This creates an issue when user uses Sentry or other solution that captures logging or exceptions. Previous implementation causes many duplicated events in Sentry if message extracted using `self._extract_error(resp)` contained such variable data.

This change uses 'non-mutable' message that is complemented with extracted data that using string formatting option supplied by Python logging. Thanks to this, Sentry and other solutions can perform better grouping of loging messages (by status code).

This is approach that is already used in handling other errors.