### PR TITLE
Solr.add supports commitWithin but not overwrite #181

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -806,7 +806,7 @@ class Solr(object):
 
         return doc_elem
 
-    def add(self, docs, boost=None, fieldUpdates=None, commit=True, softCommit=False, commitWithin=None, waitFlush=None, waitSearcher=None):
+    def add(self, docs, boost=None, fieldUpdates=None, commit=True, softCommit=False, commitWithin=None, waitFlush=None, waitSearcher=None, overwrite=None):
         """
         Adds or updates documents.
 
@@ -827,6 +827,8 @@ class Solr(object):
 
         Optionally accepts ``waitSearcher``. Default is ``None``.
 
+        Optionally accepts ``overwrite``. Default is ``None``.
+
         Usage::
 
             solr.add([
@@ -846,6 +848,9 @@ class Solr(object):
 
         if commitWithin:
             message.set('commitWithin', commitWithin)
+
+        if overwrite:
+            message.set('overwrite', overwrite)
 
         for doc in docs:
             message.append(self._build_doc(doc, boost=boost, fieldUpdates=fieldUpdates))

--- a/pysolr.py
+++ b/pysolr.py
@@ -424,7 +424,7 @@ class Solr(object):
         path = 'terms/?%s' % safe_urlencode(params, True)
         return self._send_request('get', path)
 
-    def _update(self, message, clean_ctrl_chars=True, commit=True, softCommit=False, waitFlush=None, waitSearcher=None):
+    def _update(self, message, clean_ctrl_chars=True, commit=True, softCommit=False, waitFlush=None, waitSearcher=None, overwrite=None):
         """
         Posts the given xml message to http://<self.url>/update and
         returns the result.
@@ -448,6 +448,9 @@ class Solr(object):
 
         if waitFlush is not None:
             query_vars.append('waitFlush=%s' % str(bool(waitFlush)).lower())
+
+        if overwrite is not None:
+            query_vars.append('overwrite=%s' % str(bool(overwrite)).lower())
 
         if waitSearcher is not None:
             query_vars.append('waitSearcher=%s' % str(bool(waitSearcher)).lower())
@@ -849,9 +852,6 @@ class Solr(object):
         if commitWithin:
             message.set('commitWithin', commitWithin)
 
-        if overwrite:
-            message.set('overwrite', overwrite)
-
         for doc in docs:
             message.append(self._build_doc(doc, boost=boost, fieldUpdates=fieldUpdates))
 
@@ -862,7 +862,7 @@ class Solr(object):
 
         end_time = time.time()
         self.log.debug("Built add request of %s docs in %0.2f seconds.", len(message), end_time - start_time)
-        return self._update(m, commit=commit, softCommit=softCommit, waitFlush=waitFlush, waitSearcher=waitSearcher)
+        return self._update(m, commit=commit, softCommit=softCommit, waitFlush=waitFlush, waitSearcher=waitSearcher, overwrite=overwrite)
 
     def delete(self, id=None, q=None, commit=True, waitFlush=None, waitSearcher=None):
         """

--- a/tests/client.py
+++ b/tests/client.py
@@ -540,7 +540,7 @@ class SolrTestCase(unittest.TestCase):
         self.assertEqual(len(self.solr.search('doc')), 4)
 
     def test_overwrite(self):
-        self.assertEqual(len(self.solr.search('doc_overwrite')), 0)
+        self.assertEqual(len(self.solr.search('doc_overwrite_1')), 0)
         self.solr.add([
             {
                 'id': 'doc_overwrite_1',
@@ -551,7 +551,7 @@ class SolrTestCase(unittest.TestCase):
                 'title': 'Kim is more awesome.',
             }
         ], overwrite=False)
-        self.assertEqual(len(self.solr.search('doc_overwrite_1')), 2)
+        self.assertEqual(len(self.solr.search('id:doc_overwrite_1')), 2)
 
     def test_optimize(self):
         # Make sure it doesn't blow up. Side effects are hard to measure. :/

--- a/tests/client.py
+++ b/tests/client.py
@@ -540,7 +540,7 @@ class SolrTestCase(unittest.TestCase):
         self.assertEqual(len(self.solr.search('doc')), 4)
 
     def test_overwrite(self):
-        self.assertEqual(len(self.solr.search('doc_overwrite_1')), 0)
+        self.assertEqual(len(self.solr.search('id:doc_overwrite_1')), 0)
         self.solr.add([
             {
                 'id': 'doc_overwrite_1',

--- a/tests/client.py
+++ b/tests/client.py
@@ -539,6 +539,20 @@ class SolrTestCase(unittest.TestCase):
         self.solr.commit()
         self.assertEqual(len(self.solr.search('doc')), 4)
 
+    def test_overwrite(self):
+        self.assertEqual(len(self.solr.search('doc_overwrite')), 0)
+        self.solr.add([
+            {
+                'id': 'doc_overwrite_1',
+                'title': 'Kim is awesome.',
+            },
+            {
+                'id': 'doc_overwrite_1',
+                'title': 'Kim is more awesome.',
+            }
+        ], overwrite=False)
+        self.assertEqual(len(self.solr.search('doc_overwrite_1')), 2)
+
     def test_optimize(self):
         # Make sure it doesn't blow up. Side effects are hard to measure. :/
         self.assertEqual(len(self.solr.search('doc')), 3)


### PR DESCRIPTION
Adds overwrite=True|False support option to pysolr:Solr.add
Adds testing for Solr.add overwrite option